### PR TITLE
Use -C directory instead of --git-dir

### DIFF
--- a/src/exec.ts
+++ b/src/exec.ts
@@ -13,7 +13,7 @@ export const gitExec = async function(arg) {
   // git.
   let path = await git.git.path;
   let respositories = await git.repositories;
-  var preArgs = [`--git-dir=${respositories[0].rootUri.fsPath}/.git/`];
+  var preArgs = [`-C`, `${respositories[0].rootUri.fsPath}`];
   let c = preArgs;
   if (arg) {
     c = preArgs.concat(arg);


### PR DESCRIPTION
For submodules, `.git` is not a directory, but a file containg a reference to a directory: `gitdir: ../.../.git/...`. A terminating slash breaks the call to `git branch`. One solution might be to just remove the terminating slash, but another solution is to use `-C`, and I think that is a better solution.